### PR TITLE
fix: add support for version and number comparisons

### DIFF
--- a/evaluation-core/build.gradle.kts
+++ b/evaluation-core/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                // None
+                implementation("io.github.z4kn4fein:semver:1.4.2")
             }
         }
         val commonTest by getting {

--- a/evaluation-core/src/commonMain/kotlin/SegmentTargetingConfig.kt
+++ b/evaluation-core/src/commonMain/kotlin/SegmentTargetingConfig.kt
@@ -38,10 +38,11 @@ private fun List<UserPropertyFilter>.match(user: SkylabUser?): Boolean {
                 return false
             }
         } else {
-            // if it's a version field, map the operator into an operator that
-            // supports semantic versioning. Nova doesn't have to do this,
-            // because dash does it while creating a nova query
-            val op = if (VERSION_USER_PROPS.contains(filter.prop)) {
+            // NOTE(bgiori): this is different from remote evaluation since we
+            // don't allow selecting the amplitude `version` or `start_version`
+            // user props from the UI. If the semver parsing fails the version
+            // comparison operators should fall back on a normal string compare.
+            val op = if (filter.prop.contains(SkylabUser.VERSION)) {
                 filter.op.toVersionOperator()
             } else {
                 filter.op


### PR DESCRIPTION
Original implementation did not support semantic version or numerical comparisons (<, <=, >, >=).

This PR adds this support for targeting rules with one difference from local evaluation: because we don't allow selecting the amplitude `version` or `start_version` user props from the UI, we check for if the property name **contains** the string `version` to determine if to attempt version checking. If version parsing fails, fall back on string comparison.