### PR TITLE
feat: evaluation steps in metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           cache: gradle
 
       - name: Cache Gradle Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           cache: gradle
 
       - name: Cache Gradle Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}

--- a/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
+++ b/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
@@ -194,7 +194,7 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
         return segment.variant
     }
 
-    private fun mergeMetadata(metadata1: Map<String, Any?>?, vararg metadata: Map<String, Any?>?): Map<String, Any?>? {
+    private fun mergeMetadata(vararg metadata: Map<String, Any?>?): Map<String, Any?>? {
         val mergedMetadata = mutableMapOf<String, Any?>()
         for (metadataElement in metadata) {
             if (metadataElement != null) {

--- a/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
+++ b/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
@@ -7,9 +7,26 @@ import kotlinx.serialization.json.JsonArray
 interface EvaluationEngine {
     fun evaluate(
         context: EvaluationContext,
-        flags: List<EvaluationFlag>
+        flags: List<EvaluationFlag>,
+        options: EvaluationOptions? = null
     ): Map<String, EvaluationVariant>
 }
+
+data class EvaluationOptions(
+    val showSteps: Boolean = false,
+)
+
+data class EvaluationSegmentResult(
+    val segmentMetadata: Map<String, Any?>?,
+    val conditionResult: List<List<EvaluationConditionResult>?>?,
+    val matched: Boolean
+)
+
+data class EvaluationConditionResult(
+    val propValue: Any?,
+    val condition: EvaluationCondition,
+    val matched: Boolean
+)
 
 class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
 
@@ -26,16 +43,13 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
         }
     }
 
-    override fun evaluate(
-        context: EvaluationContext,
-        flags: List<EvaluationFlag>
-    ): Map<String, EvaluationVariant> {
+    override fun evaluate(context: EvaluationContext, flags: List<EvaluationFlag>, options: EvaluationOptions?): Map<String, EvaluationVariant> {
         log?.debug { "Evaluating flags ${flags.map { it.key }} with context $context." }
         val results: MutableMap<String, EvaluationVariant> = mutableMapOf()
         val target = EvaluationTarget(context, results)
         for (flag in flags) {
             // Evaluate flag and update results.
-            val variant = evaluateFlag(target, flag)
+            val variant = evaluateFlag(target, flag, options)
             if (variant != null) {
                 results[flag.key] = variant
             } else {
@@ -46,14 +60,17 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
         return results
     }
 
-    private fun evaluateFlag(target: EvaluationTarget, flag: EvaluationFlag): EvaluationVariant? {
+    private fun evaluateFlag(target: EvaluationTarget, flag: EvaluationFlag, options: EvaluationOptions?): EvaluationVariant? {
         log?.verbose { "Evaluating flag $flag with target $target." }
         var result: EvaluationVariant? = null
+        val segmentSteps = if (options?.showSteps == true) mutableListOf<EvaluationSegmentResult?>() else null
         for (segment in flag.segments) {
-            result = evaluateSegment(target, flag, segment)
+            val resultAndSteps = evaluateSegment(target, flag, segment, options)
+            result = resultAndSteps.first
+            segmentSteps?.add(resultAndSteps.second)
             if (result != null) {
                 // Merge all metadata into the result
-                val metadata = mergeMetadata(flag.metadata, segment.metadata, result.metadata)
+                val metadata = mergeMetadata(flag.metadata, segment.metadata, result.metadata, if (segmentSteps != null) mapOf("steps" to segmentSteps) else null)
                 result = EvaluationVariant(result.key, result.value, result.payload, metadata)
                 log?.verbose { "Flag evaluation returned result $result on segment $segment." }
                 break
@@ -65,21 +82,28 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
     private fun evaluateSegment(
         target: EvaluationTarget,
         flag: EvaluationFlag,
-        segment: EvaluationSegment
-    ): EvaluationVariant? {
+        segment: EvaluationSegment,
+        options: EvaluationOptions?
+    ): Pair<EvaluationVariant?, EvaluationSegmentResult?> { // Pair of variant and justification
         log?.verbose { "Evaluating segment $segment with target $target." }
         if (segment.conditions == null) {
             log?.verbose { "Segment conditions are null, bucketing target." }
             // Null conditions always match
             val variantKey = bucket(target, segment)
-            return flag.variants[variantKey]
+            return flag.variants[variantKey] to if (options?.showSteps == true)
+                EvaluationSegmentResult(segment.metadata, null, true)
+            else null
         }
+        val orConditionLogs = (if (options?.showSteps == true) mutableListOf<List<EvaluationConditionResult>?>() else null)
         // Outer list logic is "or" (||)
         for (conditions in segment.conditions) {
             var match = true
             // Inner list logic is "and" (&&)
+            val andConditionLogs = (if (options?.showSteps == true) mutableListOf<EvaluationConditionResult>() else null)
             for (condition in conditions) {
-                match = matchCondition(target, condition)
+                val propValue = target.select(condition.selector)
+                match = matchCondition(propValue, condition)
+                andConditionLogs?.add(EvaluationConditionResult(propValue, condition, match))
                 if (!match) {
                     log?.verbose { "Segment condition $condition did not match target." }
                     break
@@ -87,18 +111,22 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
                     log?.verbose { "Segment condition $condition matched target." }
                 }
             }
+            orConditionLogs?.add(andConditionLogs)
             // On match bucket the user.
             if (match) {
                 log?.verbose { "Segment conditions matched, bucketing target." }
                 val variantKey = bucket(target, segment)
-                return flag.variants[variantKey]
+                return flag.variants[variantKey] to if (options?.showSteps == true)
+                    EvaluationSegmentResult(segment.metadata, orConditionLogs, true)
+                else null
             }
         }
-        return null
+        return null to if (options?.showSteps == true)
+            EvaluationSegmentResult(segment.metadata, orConditionLogs, false)
+        else null
     }
 
-    private fun matchCondition(target: EvaluationTarget, condition: EvaluationCondition): Boolean {
-        val propValue = target.select(condition.selector)
+    private fun matchCondition(propValue: Any?, condition: EvaluationCondition): Boolean {
         // We need special matching for null properties and set type prop values
         // and operators. All other values are matched as strings, since the
         // filter values are always strings.
@@ -160,7 +188,7 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
         return segment.variant
     }
 
-    private fun mergeMetadata(vararg metadata: Map<String, Any?>?): Map<String, Any?>? {
+    private fun mergeMetadata(metadata1: Map<String, Any?>?, vararg metadata: Map<String, Any?>?): Map<String, Any?>? {
         val mergedMetadata = mutableMapOf<String, Any?>()
         for (metadataElement in metadata) {
             if (metadataElement != null) {

--- a/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
+++ b/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
@@ -13,7 +13,7 @@ interface EvaluationEngine {
 }
 
 data class EvaluationOptions(
-    val showSteps: Boolean = false,
+    val showSteps: Boolean = false
 )
 
 data class EvaluationSegmentResult(
@@ -90,9 +90,11 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
             log?.verbose { "Segment conditions are null, bucketing target." }
             // Null conditions always match
             val variantKey = bucket(target, segment)
-            return flag.variants[variantKey] to if (options?.showSteps == true)
+            return flag.variants[variantKey] to if (options?.showSteps == true) {
                 EvaluationSegmentResult(segment.metadata, null, true)
-            else null
+            } else {
+                null
+            }
         }
         val orConditionLogs = (if (options?.showSteps == true) mutableListOf<List<EvaluationConditionResult>?>() else null)
         // Outer list logic is "or" (||)
@@ -116,14 +118,18 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
             if (match) {
                 log?.verbose { "Segment conditions matched, bucketing target." }
                 val variantKey = bucket(target, segment)
-                return flag.variants[variantKey] to if (options?.showSteps == true)
+                return flag.variants[variantKey] to if (options?.showSteps == true) {
                     EvaluationSegmentResult(segment.metadata, orConditionLogs, true)
-                else null
+                } else {
+                    null
+                }
             }
         }
-        return null to if (options?.showSteps == true)
+        return null to if (options?.showSteps == true) {
             EvaluationSegmentResult(segment.metadata, orConditionLogs, false)
-        else null
+        } else {
+            null
+        }
     }
 
     private fun matchCondition(propValue: Any?, condition: EvaluationCondition): Boolean {

--- a/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
+++ b/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
@@ -8,18 +8,25 @@ interface EvaluationEngine {
     fun evaluate(
         context: EvaluationContext,
         flags: List<EvaluationFlag>,
-        options: EvaluationOptions? = null
     ): Map<String, EvaluationVariant>
+
+    fun getEvaluationTraces(
+        context: EvaluationContext,
+        flags: List<EvaluationFlag>,
+    ): Map<String, EvaluationTrace>
 }
 
-data class EvaluationOptions(
-    val showSteps: Boolean = false
+data class EvaluationTrace(
+    val variant: EvaluationVariant?,
+    val steps: List<EvaluationStep>
 )
 
-data class EvaluationSegmentResult(
-    val segmentMetadata: Map<String, Any?>?,
-    val conditionResult: List<List<EvaluationConditionResult>?>?,
-    val matched: Boolean
+data class EvaluationStep(
+    val segmentName: String?,
+    val conditionsPassed: Boolean,
+    val bucketed: Boolean,
+    val bucketVariant: String?,
+    val conditions: List<List<EvaluationConditionResult>?>?
 )
 
 data class EvaluationConditionResult(
@@ -43,13 +50,12 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
         }
     }
 
-    override fun evaluate(context: EvaluationContext, flags: List<EvaluationFlag>, options: EvaluationOptions?): Map<String, EvaluationVariant> {
+    override fun evaluate(context: EvaluationContext, flags: List<EvaluationFlag>): Map<String, EvaluationVariant> {
         log?.debug { "Evaluating flags ${flags.map { it.key }} with context $context." }
         val results: MutableMap<String, EvaluationVariant> = mutableMapOf()
         val target = EvaluationTarget(context, results)
         for (flag in flags) {
-            // Evaluate flag and update results.
-            val variant = evaluateFlag(target, flag, options)
+            val variant = evaluateFlag(target, flag, null)
             if (variant != null) {
                 results[flag.key] = variant
             } else {
@@ -60,17 +66,30 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
         return results
     }
 
-    private fun evaluateFlag(target: EvaluationTarget, flag: EvaluationFlag, options: EvaluationOptions?): EvaluationVariant? {
+    override fun getEvaluationTraces(context: EvaluationContext, flags: List<EvaluationFlag>): Map<String, EvaluationTrace> {
+        log?.debug { "Evaluating flags with traces ${flags.map { it.key }} with context $context." }
+        val results: MutableMap<String, EvaluationVariant> = mutableMapOf()
+        val traces: MutableMap<String, EvaluationTrace> = mutableMapOf()
+        val target = EvaluationTarget(context, results)
+        for (flag in flags) {
+            val steps = mutableListOf<EvaluationStep>()
+            val variant = evaluateFlag(target, flag, steps)
+            if (variant != null) {
+                results[flag.key] = variant
+            }
+            traces[flag.key] = EvaluationTrace(variant, steps)
+        }
+        log?.debug { "Evaluation with traces completed. $traces" }
+        return traces
+    }
+
+    private fun evaluateFlag(target: EvaluationTarget, flag: EvaluationFlag, steps: MutableList<EvaluationStep>?): EvaluationVariant? {
         log?.verbose { "Evaluating flag $flag with target $target." }
         var result: EvaluationVariant? = null
-        val segmentSteps = if (options?.showSteps == true) mutableListOf<EvaluationSegmentResult?>() else null
         for (segment in flag.segments) {
-            val resultAndSteps = evaluateSegment(target, flag, segment, options)
-            result = resultAndSteps.first
-            segmentSteps?.add(resultAndSteps.second)
+            result = evaluateSegment(target, flag, segment, steps)
             if (result != null) {
-                // Merge all metadata into the result
-                val metadata = mergeMetadata(flag.metadata, segment.metadata, result.metadata, if (segmentSteps != null) mapOf("steps" to segmentSteps) else null)
+                val metadata = mergeMetadata(flag.metadata, segment.metadata, result.metadata)
                 result = EvaluationVariant(result.key, result.value, result.payload, metadata)
                 log?.verbose { "Flag evaluation returned result $result on segment $segment." }
                 break
@@ -83,25 +102,29 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
         target: EvaluationTarget,
         flag: EvaluationFlag,
         segment: EvaluationSegment,
-        options: EvaluationOptions?
-    ): Pair<EvaluationVariant?, EvaluationSegmentResult?> { // Pair of variant and justification
+        steps: MutableList<EvaluationStep>?,
+    ): EvaluationVariant? {
         log?.verbose { "Evaluating segment $segment with target $target." }
+        val segmentName = if (steps != null) segment.metadata?.get("segmentName") as? String else null
         if (segment.conditions == null) {
             log?.verbose { "Segment conditions are null, bucketing target." }
-            // Null conditions always match
             val variantKey = bucket(target, segment)
-            return flag.variants[variantKey] to if (options?.showSteps == true) {
-                EvaluationSegmentResult(segment.metadata, null, true)
-            } else {
-                null
-            }
+            val variant = flag.variants[variantKey]
+            steps?.add(EvaluationStep(
+                segmentName = segmentName,
+                conditionsPassed = true,
+                bucketed = variant != null,
+                bucketVariant = variantKey,
+                conditions = null
+            ))
+            return variant
         }
-        val orConditionLogs = (if (options?.showSteps == true) mutableListOf<List<EvaluationConditionResult>?>() else null)
+        val orConditionLogs = if (steps != null) mutableListOf<List<EvaluationConditionResult>?>() else null
         // Outer list logic is "or" (||)
         for (conditions in segment.conditions) {
             var match = true
+            val andConditionLogs = if (steps != null) mutableListOf<EvaluationConditionResult>() else null
             // Inner list logic is "and" (&&)
-            val andConditionLogs = (if (options?.showSteps == true) mutableListOf<EvaluationConditionResult>() else null)
             for (condition in conditions) {
                 val propValue = target.select(condition.selector)
                 match = matchCondition(propValue, condition)
@@ -118,18 +141,25 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
             if (match) {
                 log?.verbose { "Segment conditions matched, bucketing target." }
                 val variantKey = bucket(target, segment)
-                return flag.variants[variantKey] to if (options?.showSteps == true) {
-                    EvaluationSegmentResult(segment.metadata, orConditionLogs, true)
-                } else {
-                    null
-                }
+                val variant = flag.variants[variantKey]
+                steps?.add(EvaluationStep(
+                    segmentName = segmentName,
+                    conditionsPassed = true,
+                    bucketed = variant != null,
+                    bucketVariant = variantKey,
+                    conditions = orConditionLogs
+                ))
+                return variant
             }
         }
-        return null to if (options?.showSteps == true) {
-            EvaluationSegmentResult(segment.metadata, orConditionLogs, false)
-        } else {
-            null
-        }
+        steps?.add(EvaluationStep(
+            segmentName = segmentName,
+            conditionsPassed = false,
+            bucketed = false,
+            bucketVariant = segment.variant,
+            conditions = orConditionLogs
+        ))
+        return null
     }
 
     private fun matchCondition(propValue: Any?, condition: EvaluationCondition): Boolean {

--- a/evaluation-core/src/commonTest/kotlin/EvaluationIntegrationTest.kt
+++ b/evaluation-core/src/commonTest/kotlin/EvaluationIntegrationTest.kt
@@ -9,7 +9,7 @@ private const val DEPLOYMENT_KEY = "server-NgJxxvg8OGwwBsWVXqyxQbdiflbhvugy"
 
 class EvaluationIntegrationTest {
 
-    private val engine: EvaluationEngine = EvaluationEngineImpl()
+    private val engine: EvaluationEngineImpl = EvaluationEngineImpl()
     private val flags: List<EvaluationFlag> = runBlocking {
         FlagApi().getFlagConfigs(DEPLOYMENT_KEY)
     }
@@ -36,6 +36,27 @@ class EvaluationIntegrationTest {
             "on",
             result?.key
         )
+    }
+
+    @Test
+    fun `test on with steps`() {
+        val user = userContext(userId = "user_id", deviceId = "device_id")
+        val results = engine.evaluate(user, flags, EvaluationOptions(showSteps = true))
+        DefaultAsserter.assertEquals(
+            "Unexpected evaluation result",
+            "on",
+            results["test-on"]?.key
+        )
+        val stepsRaw = results["test-on"]?.metadata?.get("steps")
+        DefaultAsserter.assertNotNull("Steps not found", stepsRaw)
+        val steps = stepsRaw as List<*>
+        DefaultAsserter.assertEquals("Unexpected steps size", 1, steps.size)
+        val step = steps[0] as EvaluationSegmentResult
+        DefaultAsserter.assertEquals("Unexpected step segment name", "All Other Users",
+            step.segmentMetadata?.get("segmentName")
+        )
+        DefaultAsserter.assertNull("Unexpected step condition result", step.conditionResult)
+        DefaultAsserter.assertTrue("Unexpected step matched", step.matched)
     }
 
     // Opinionated Segment Tests

--- a/evaluation-core/src/commonTest/kotlin/EvaluationIntegrationTest.kt
+++ b/evaluation-core/src/commonTest/kotlin/EvaluationIntegrationTest.kt
@@ -52,7 +52,9 @@ class EvaluationIntegrationTest {
         val steps = stepsRaw as List<*>
         DefaultAsserter.assertEquals("Unexpected steps size", 1, steps.size)
         val step = steps[0] as EvaluationSegmentResult
-        DefaultAsserter.assertEquals("Unexpected step segment name", "All Other Users",
+        DefaultAsserter.assertEquals(
+            "Unexpected step segment name",
+            "All Other Users",
             step.segmentMetadata?.get("segmentName")
         )
         DefaultAsserter.assertNull("Unexpected step condition result", step.conditionResult)

--- a/evaluation-core/src/commonTest/kotlin/EvaluationIntegrationTest.kt
+++ b/evaluation-core/src/commonTest/kotlin/EvaluationIntegrationTest.kt
@@ -39,26 +39,28 @@ class EvaluationIntegrationTest {
     }
 
     @Test
-    fun `test on with steps`() {
+    fun `test on with traces`() {
         val user = userContext(userId = "user_id", deviceId = "device_id")
-        val results = engine.evaluate(user, flags, EvaluationOptions(showSteps = true))
+        val traces = engine.getEvaluationTraces(user, flags)
+        val trace = traces["test-on"]
+        DefaultAsserter.assertNotNull("Trace not found", trace)
         DefaultAsserter.assertEquals(
             "Unexpected evaluation result",
             "on",
-            results["test-on"]?.key
+            trace!!.variant?.key
         )
-        val stepsRaw = results["test-on"]?.metadata?.get("steps")
-        DefaultAsserter.assertNotNull("Steps not found", stepsRaw)
-        val steps = stepsRaw as List<*>
+        val steps = trace.steps
         DefaultAsserter.assertEquals("Unexpected steps size", 1, steps.size)
-        val step = steps[0] as EvaluationSegmentResult
+        val step = steps[0]
         DefaultAsserter.assertEquals(
             "Unexpected step segment name",
             "All Other Users",
-            step.segmentMetadata?.get("segmentName")
+            step.segmentName
         )
-        DefaultAsserter.assertNull("Unexpected step condition result", step.conditionResult)
-        DefaultAsserter.assertTrue("Unexpected step matched", step.matched)
+        DefaultAsserter.assertNull("Unexpected step conditions", step.conditions)
+        DefaultAsserter.assertTrue("Unexpected conditionsPassed", step.conditionsPassed)
+        DefaultAsserter.assertTrue("Unexpected bucketed", step.bucketed)
+        DefaultAsserter.assertEquals("Unexpected bucketVariant", "on", step.bucketVariant)
     }
 
     // Opinionated Segment Tests


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add evaluation step logging via `EvaluationEngine.evaluate(options: EvaluationOptions?)` and merge `steps` into variant metadata in [EvaluationEngine.kt](https://github.com/amplitude/experiment-evaluation/pull/9/files#diff-9552a131f4af7357695e7e7b53a9b9e7b4a9a84dbc6afba264780596cbe6d6e4)
Introduce `EvaluationOptions(showSteps)` and per-segment step results (`EvaluationSegmentResult`, `EvaluationConditionResult`), update `EvaluationEngineImpl` evaluation methods to collect and merge `steps` into variant metadata, and adjust `matchCondition` to accept `propValue`. Tests cover step logging in [EvaluationIntegrationTest.kt](https://github.com/amplitude/experiment-evaluation/pull/9/files#diff-fab7445b40d708c7a882f846a46a18eafc747fc3215849cc9f20232e1d8c3f14).

#### 📍Where to Start
Start with `EvaluationEngineImpl.evaluate` in [EvaluationEngine.kt](https://github.com/amplitude/experiment-evaluation/pull/9/files#diff-9552a131f4af7357695e7e7b53a9b9e7b4a9a84dbc6afba264780596cbe6d6e4).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 2aa146f. (Automatic summaries will resume when PR exits draft mode or review begins).
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->