### PR TITLE
fix: handle targeting on array/multi-value property values with non-set operators 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,5 @@ jobs:
           distribution: zulu
           cache: gradle
 
-      - name: Cache Gradle Dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
-
       - name: Build
         run: ./gradlew assemble

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,5 @@ jobs:
           distribution: zulu
           cache: gradle
 
-      - name: Cache Gradle Dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
-
       - name: Test
         run: ./gradlew jvmTest --info

--- a/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
+++ b/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
@@ -354,6 +354,10 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
         // Parse a string as json array and convert to list of strings, or
         // return null if the string could not be parsed as a json array.
         val stringValue = value.toString()
+        // Naive check to avoid exception handling resource consumption
+        if (!stringValue.startsWith("[")) {
+            return null
+        }
         val jsonArray = try {
             json.decodeFromString<JsonArray>(stringValue)
         } catch (e: SerializationException) {

--- a/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
+++ b/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
@@ -209,10 +209,15 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
         }
     }
 
+    // Matches non-set operators against multi-value properties by checking if any
+    // element satisfies the operator. This follows analytics/charts filtering
+    // behavior where e.g. "is" matches if any array element equals the filter value.
+    // Note: negation operators (is not, does not contain) also use any-match semantics,
+    // meaning the condition is true if any single element satisfies the negation —
+    // not if all elements do. For example, "is not A" on ["A", "B"] is true because
+    // "B" is not "A", even though "A" is present.
     private fun matchStringsNonSet(propValues: Set<String>, op: String, filterValues: Set<String>): Boolean {
-        return propValues.fold(false) { acc, propValue ->
-            acc || matchString(propValue, op, filterValues)
-        }
+        return propValues.any { matchString(it, op, filterValues) }
     }
 
     private fun matchString(propValue: String, op: String, filterValues: Set<String>): Boolean {

--- a/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
+++ b/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
@@ -357,10 +357,6 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
         return jsonArray.toList().mapNotNull { coerceString(it) }.toSet()
     }
 
-    private fun isCollectionValue(value: Any?): Boolean {
-        return value is Collection<*>
-    }
-
     private fun isSetOperator(op: String): Boolean {
         return when (op) {
             EvaluationOperator.SET_IS,

--- a/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
+++ b/evaluation-core/src/commonMain/kotlin/EvaluationEngine.kt
@@ -104,12 +104,16 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
         // filter values are always strings.
         if (propValue == null) {
             return matchNull(condition.op, condition.values)
-        } else if (isSetOperator(condition.op)) {
-            val propValueStringList = coerceStringList(propValue) ?: return false
-            return matchSet(propValueStringList, condition.op, condition.values)
         } else {
-            val propValueString = coerceString(propValue) ?: return false
-            return matchString(propValueString, condition.op, condition.values)
+            val propValueStringList = coerceStringList(propValue)
+            if (isSetOperator(condition.op)) {
+                return propValueStringList?.let { matchSet(it, condition.op, condition.values) } ?: false
+            } else if (propValueStringList != null) {
+                return matchStringsNonSet(propValueStringList, condition.op, condition.values)
+            } else {
+                val propValueString = coerceString(propValue) ?: return false
+                return matchString(propValueString, condition.op, condition.values)
+            }
         }
     }
 
@@ -202,6 +206,12 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
             EvaluationOperator.SET_CONTAINS_ANY -> matchesSetContainsAny(propValues, filterValues)
             EvaluationOperator.SET_DOES_NOT_CONTAIN_ANY -> !matchesSetContainsAny(propValues, filterValues)
             else -> false
+        }
+    }
+
+    private fun matchStringsNonSet(propValues: Set<String>, op: String, filterValues: Set<String>): Boolean {
+        return propValues.fold(false) { acc, propValue ->
+            acc || matchString(propValue, op, filterValues)
         }
     }
 
@@ -345,6 +355,10 @@ class EvaluationEngineImpl(private val log: Logger? = null) : EvaluationEngine {
             return null
         }
         return jsonArray.toList().mapNotNull { coerceString(it) }.toSet()
+    }
+
+    private fun isCollectionValue(value: Any?): Boolean {
+        return value is Collection<*>
     }
 
     private fun isSetOperator(op: String): Boolean {

--- a/evaluation-core/src/commonTest/kotlin/EvaluationCoerceStringListTest.kt
+++ b/evaluation-core/src/commonTest/kotlin/EvaluationCoerceStringListTest.kt
@@ -1,0 +1,103 @@
+package com.amplitude.experiment.evaluation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+private val engine: EvaluationEngine = EvaluationEngineImpl()
+
+private fun flagWithCondition(op: String, values: Set<String>): EvaluationFlag {
+    return EvaluationFlag(
+        key = "test-flag",
+        variants = mapOf("on" to EvaluationVariant(key = "on")),
+        segments = listOf(
+            EvaluationSegment(
+                conditions = listOf(
+                    listOf(
+                        EvaluationCondition(
+                            selector = listOf("context", "user", "user_properties", "test_prop"),
+                            op = op,
+                            values = values
+                        )
+                    )
+                ),
+                variant = "on"
+            )
+        )
+    )
+}
+
+private fun contextWithProp(value: Any?): EvaluationContext {
+    return EvaluationContext().apply {
+        put(
+            "user",
+            mutableMapOf<String, Any?>(
+                "user_properties" to mutableMapOf<String, Any?>("test_prop" to value)
+            )
+        )
+    }
+}
+
+private fun evaluate(propValue: Any?, op: String, values: Set<String>): EvaluationVariant? {
+    val flag = flagWithCondition(op, values)
+    return engine.evaluate(contextWithProp(propValue), listOf(flag))["test-flag"]
+}
+
+private fun assertMatch(propValue: Any?, op: String, values: Set<String>) {
+    val result = evaluate(propValue, op, values)
+    assertNotNull(result, "Expected match for propValue=$propValue op=$op values=$values")
+    assertEquals("on", result.key)
+}
+
+private fun assertNoMatch(propValue: Any?, op: String, values: Set<String>) {
+    assertNull(
+        evaluate(propValue, op, values),
+        "Expected no match for propValue=$propValue op=$op values=$values"
+    )
+}
+
+class EvaluationCoerceStringListTest {
+
+    @Test
+    fun `scalar string with non-set operators matches via string path`() {
+        assertMatch("hello", EvaluationOperator.IS, setOf("hello"))
+        assertMatch("hello", EvaluationOperator.CONTAINS, setOf("ell"))
+        assertMatch("2", EvaluationOperator.GREATER_THAN, setOf("1"))
+        assertNoMatch("world", EvaluationOperator.IS, setOf("hello"))
+    }
+
+    @Test
+    fun `json array string parses correctly`() {
+        assertMatch("""["a","b"]""", EvaluationOperator.SET_CONTAINS, setOf("a"))
+        assertMatch("""["a","b"]""", EvaluationOperator.IS, setOf("a"))
+    }
+
+    @Test
+    fun `collection values work with both operator types`() {
+        assertMatch(listOf("a", "b"), EvaluationOperator.SET_CONTAINS, setOf("a"))
+        assertMatch(listOf("a", "b"), EvaluationOperator.IS, setOf("a"))
+    }
+
+    @Test
+    fun `non-string scalar with non-set operator matches via string path`() {
+        assertMatch(42, EvaluationOperator.GREATER_THAN, setOf("1"))
+        assertMatch(true, EvaluationOperator.IS, setOf("true"))
+    }
+
+    @Test
+    fun `malformed json array falls through to string match`() {
+        assertMatch("[broken", EvaluationOperator.IS, setOf("[broken"))
+    }
+
+    @Test
+    fun `empty json array returns no match for set operator`() {
+        assertNoMatch("[]", EvaluationOperator.SET_CONTAINS, setOf("a"))
+    }
+
+    @Test
+    fun `string with leading whitespace before bracket does not parse as array`() {
+        assertMatch(""" ["a"]""", EvaluationOperator.IS, setOf(""" ["a"]"""))
+        assertNoMatch(""" ["a"]""", EvaluationOperator.SET_CONTAINS, setOf("a"))
+    }
+}

--- a/evaluation-core/src/commonTest/kotlin/EvaluationIntegrationTest.kt
+++ b/evaluation-core/src/commonTest/kotlin/EvaluationIntegrationTest.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.runBlocking
 import kotlin.test.DefaultAsserter
 import kotlin.test.Test
 
-private const val DEPLOYMENT_KEY = "server-NgJxxvg8OGwwBsWVXqyxQbdiflbhvugy"
+private const val DEPLOYMENT_KEY = "server-VVhLULXCxxY0xqmszXouXxiEzoeJWmSh"
 
 class EvaluationIntegrationTest {
 

--- a/evaluation-core/src/commonTest/kotlin/EvaluationIntegrationTest.kt
+++ b/evaluation-core/src/commonTest/kotlin/EvaluationIntegrationTest.kt
@@ -728,6 +728,21 @@ class EvaluationIntegrationTest {
     }
 
     @Test
+    fun `test set is json array`() {
+        val user = userContext(
+            userProperties = mapOf(
+                "key" to "[\"1\", \"2\", \"3\"]"
+            )
+        )
+        val result = engine.evaluate(user, flags)["test-set-is"]
+        DefaultAsserter.assertEquals(
+            "Unexpected evaluation result",
+            "on",
+            result?.key
+        )
+    }
+
+    @Test
     fun `test set is not`() {
         val user = userContext(
             userProperties = mapOf(
@@ -876,6 +891,96 @@ class EvaluationIntegrationTest {
         )
 
         val result = engine.evaluate(user, flags.filter { it.key == "test-version-less" })["test-version-less"]
+        DefaultAsserter.assertEquals(
+            "Unexpected evaluation result",
+            "on",
+            result?.key
+        )
+    }
+
+    @Test
+    fun `test is with array values`() {
+        val user = userContext(
+            userProperties = mapOf(
+                "key" to listOf("value1", "value2")
+            )
+        )
+        val result = engine.evaluate(user, flags)["test-is-array"]
+        DefaultAsserter.assertEquals(
+            "Unexpected evaluation result",
+            "on",
+            result?.key
+        )
+    }
+
+    @Test
+    fun `test is not with array values`() {
+        val user = userContext(
+            userProperties = mapOf(
+                "key" to listOf("value3", "value4")
+            )
+        )
+        val result = engine.evaluate(user, flags)["test-is-not-array"]
+        DefaultAsserter.assertEquals(
+            "Unexpected evaluation result",
+            "on",
+            result?.key
+        )
+    }
+
+    @Test
+    fun `test contains with array values`() {
+        val user = userContext(
+            userProperties = mapOf(
+                "key" to listOf("has-target-value", "has", "value")
+            )
+        )
+        val result = engine.evaluate(user, flags)["test-contains-array"]
+        DefaultAsserter.assertEquals(
+            "Unexpected evaluation result",
+            "on",
+            result?.key
+        )
+    }
+
+    @Test
+    fun `test does not contain with array values`() {
+        val user = userContext(
+            userProperties = mapOf(
+                "key" to listOf("has-value", "has", "value")
+            )
+        )
+        val result = engine.evaluate(user, flags)["test-does-not-contain-array"]
+        DefaultAsserter.assertEquals(
+            "Unexpected evaluation result",
+            "on",
+            result?.key
+        )
+    }
+
+    @Test
+    fun `test is with json array value`() {
+        val user = userContext(
+            userProperties = mapOf(
+                "key" to "[\"value1\", \"value2\"]"
+            )
+        )
+        val result = engine.evaluate(user, flags)["test-is-array"]
+        DefaultAsserter.assertEquals(
+            "Unexpected evaluation result",
+            "on",
+            result?.key
+        )
+    }
+
+    @Test
+    fun `test does not contain with json array values`() {
+        val user = userContext(
+            userProperties = mapOf(
+                "key" to "[\"has-value\", \"has\", \"value\"]"
+            )
+        )
+        val result = engine.evaluate(user, flags)["test-does-not-contain-array"]
         DefaultAsserter.assertEquals(
             "Unexpected evaluation result",
             "on",


### PR DESCRIPTION
DO NO MERGE - Test case needs to be added to the remote test input before merging.

> Analytics/Charts distinguishes between **set operators** (`SET_IS`, `SET_CONTAINS`, `SET_CONTAINS_ANY`, etc.) and **non‑set operators** (`IS`, `CONTAINS`, comparisons) when evaluating array‑valued properties:
> - Set operators treat the property as a **set** and operate on the **entire array** (e.g., `SET_CONTAINS_ANY` = “at least one element in the array is in the filter set”; `SET_IS` = “the array equals the filter set”).  
> - Non‑set operators are applied **per element**, and the row passes if **any element** matches (e.g., `prop CONTAINS "foo"` passes if any element contains `"foo"`).
> 
> The local `experiment-evaluation` engine already has separate paths for set vs non‑set operators, but previously we didn’t consistently surface **array values as collections**, so some multi‑valued properties were effectively treated as scalars. The `is-array-values` changes:
> - Correctly detect array‑valued properties in the user/context.  
> - Feed them as collections into the existing **set** path for `SET_*` operators.  
> - Let **non‑set** operators run per element with “any element matches” semantics.
> 
> This aligns local evaluation behavior with Nova’s `StringMatchColumnFilter` / numeric filters and removes discrepancies for flags targeting multi‑valued properties (e.g., cohorts, list‑like user props).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core flag-targeting evaluation semantics for array/JSON-array property values, which could alter which users qualify for experiments if assumptions differ. Added tests reduce regression risk but behavior for negation operators uses any-match semantics that may surprise.
> 
> **Overview**
> Fixes flag targeting when a property is multi-valued (collection or JSON array string) by routing `SET_*` operators through set matching and applying *non-set* operators (`IS`, `CONTAINS`, comparisons, etc.) per element with **any-element-matches** semantics via `matchStringsNonSet`.
> 
> Hardens `coerceStringList` by skipping JSON parsing unless the string starts with `[` to avoid exception overhead, and adds unit/integration coverage for array and JSON-array inputs (including negation cases). CI workflows also drop the explicit Gradle cache step, relying on `setup-java`’s built-in Gradle caching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bace44109b54b50b7976683f7e5e7420097b7af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->