### PR TITLE
chore: update gh release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,7 @@ jobs:
       - name: ${{ github.actor }} permission check to do a release
         uses: octokit/request-action@v2.0.0
         with:
-          route: GET /repos/:repository/collaborators/${{ github.actor }}
-          repository: ${{ github.repository }}
+          route: GET /repos/${{ github.repository }}/collaborators/${{ github.actor }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to the release workflow’s permission-check API call; impact is limited to whether the workflow correctly authorizes releases.
> 
> **Overview**
> Fixes the `authorize` job in `.github/workflows/release.yml` by updating the Octokit request route to use an explicit `/repos/${{ github.repository }}/collaborators/${{ github.actor }}` path instead of the `:repository` placeholder.
> 
> This should make the release permission check resolve the correct endpoint before running the `release` job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caa2881e29bba92c21870332f61aadc0179b28e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->