### PR TITLE
chore: fix published artifact name

### DIFF
--- a/evaluation-core/build.gradle.kts
+++ b/evaluation-core/build.gradle.kts
@@ -48,7 +48,7 @@ kotlin {
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
     signAllPublications()
-    coordinates("com.amplitude", "experiment-evaluation", version.toString())
+    coordinates("com.amplitude", "evaluation-core", version.toString())
     pom {
         name.set("Amplitude Experiment Evaluation")
         description.set("Core kotlin multiplatform package for Amplitude Experiment's evaluation.")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to Maven publishing metadata; main impact is on consumers who depend on the previously published (incorrect) artifactId.
> 
> **Overview**
> Fixes the published Maven coordinates for `evaluation-core` by changing the artifactId from `experiment-evaluation` to `evaluation-core` in `evaluation-core/build.gradle.kts`, ensuring the module is released under the correct name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3302f898ae1fda4978930753625ef5e234b9a93e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->